### PR TITLE
LCFS support for MacOS/Apple

### DIFF
--- a/lcfs/Makefile
+++ b/lcfs/Makefile
@@ -1,7 +1,13 @@
 # lcfs Makefile -- 201701.06MeV
 CC=gcc
-CFLAGS=-g -Wall -D_FILE_OFFSET_BITS=64 -I/usr/include/fuse -I/usr/local/include/fuse
-LDFLAGS=-lz -ltcmalloc -pthread -lprofiler -lfuse
+UNAME=$(shell uname)
+ifeq ($(UNAME),Linux)
+	CFLAGS=-g -Wall $ -D_FILE_OFFSET_BITS=64 -I/usr/include/fuse -I/usr/local/include/fuse
+	LDFLAGS=-ltcmalloc -pthread -lprofiler -lfuse -lz
+else
+	CFLAGS=-g -Wno-format $ -D_FILE_OFFSET_BITS=64 -I/usr/local/include/osxfuse/fuse -I/usr/local/include/osxfuse
+	LDFLAGS=-ltcmalloc -lprofiler -losxfuse -lz
+endif
 #CFLAGS=-g -Wall $ -D_FILE_OFFSET_BITS=64 -I/usr/local/include/fuse3
 #LDFLAGS=-lz -ltcmalloc -pthread -L/usr/local/lib -lfuse3
 

--- a/lcfs/apple.h
+++ b/lcfs/apple.h
@@ -1,0 +1,8 @@
+#define _IOC_NRBITS     8
+#define _IOC_TYPEBITS   8
+#define _IOC_NRMASK     ((1 << _IOC_NRBITS)-1)
+#define _IOC_TYPEMASK   ((1 << _IOC_TYPEBITS)-1)
+#define _IOC_NRSHIFT    0
+#define _IOC_TYPESHIFT  (_IOC_NRSHIFT+_IOC_NRBITS)
+#define _IOC_TYPE(nr)           (((nr) >> _IOC_TYPESHIFT) & _IOC_TYPEMASK)
+#define _IOC_NR(nr)             (((nr) >> _IOC_NRSHIFT) & _IOC_NRMASK)

--- a/lcfs/fs.c
+++ b/lcfs/fs.c
@@ -514,12 +514,24 @@ lc_mount(char *device, struct gfs **gfsp) {
     lc_memoryInit();
 
     /* Open the device for mounting */
+#ifdef __APPLE__
+    fd = open(device, O_RDWR | O_EXCL, 0);
+#else
     fd = open(device, O_RDWR | O_DIRECT | O_EXCL | O_NOATIME, 0);
+#endif
     if (fd == -1) {
         perror("open");
         return errno;
     }
 
+#ifdef __APPLE__
+    int ret;
+    ret = fcntl(fd, F_NOCACHE);
+    if (ret == -1) {
+      perror("fcntl");
+      return errno;
+    }
+#endif
     /* Find the size of the device and calculate total blocks */
     size = lseek(fd, 0, SEEK_END);
     if (size == -1) {

--- a/lcfs/includes.h
+++ b/lcfs/includes.h
@@ -24,16 +24,25 @@
 #include <string.h>
 #include <errno.h>
 #include <fcntl.h>
+#ifdef __APPLE__
+#include <sys/sysctl.h>
+#else
 #include <sys/sysinfo.h>
+#endif
 #include <sys/time.h>
 #include <sys/xattr.h>
 #include <pthread.h>
 #include <zlib.h>
 #include <assert.h>
-#include <linux/ioctl.h>
+#include <sys/ioctl.h>
 
 #ifdef LC_PROFILING
 #include <gperftools/profiler.h>
+#endif
+
+#ifdef __APPLE__
+#include <mach/clock.h>
+#include <mach/mach.h>
 #endif
 
 #include "lcfs.h"
@@ -45,6 +54,10 @@
 #include "page.h"
 #include "stats.h"
 #include "inlines.h"
+
+#ifdef __APPLE__
+#include "apple.h"
+#endif
 
 struct gfs *getfs();
 

--- a/lcfs/inode.h
+++ b/lcfs/inode.h
@@ -43,6 +43,9 @@ struct icache {
 /* Portion of the readdir offset storing index in the list */
 #define LC_DIRHASH_INDEX 0x00000000FFFFFFFFul
 
+/* Padding used for Darwin */
+#define DARWIN_DINODE_SIZE 6
+
 /* Directory entry */
 struct dirent {
 
@@ -182,8 +185,17 @@ struct inode {
 
     /* Various flags */
     uint32_t i_flags;
+
+#ifdef __APPLE__
+   /* Padding for darwin */
+   char opaque[DARWIN_DINODE_SIZE];
+#endif
 }  __attribute__((packed));
+#ifdef __APPLE__
+static_assert(sizeof(struct inode) <= 512, "inode size <= 512");
+#else
 static_assert(sizeof(struct inode) == 216, "inode size != 216");
+#endif
 static_assert((sizeof(struct inode) % sizeof(void *)) == 0,
               "Inode size is not aligned");
 

--- a/lcfs/layout.h
+++ b/lcfs/layout.h
@@ -214,7 +214,11 @@ struct dinode {
     /* Block tracking extended attributes */
     uint64_t di_xattr;
 } __attribute__((packed));
+#ifdef __APPLE__
+static_assert(sizeof(struct dinode) <= 98, "dinode size != 98");
+#else
 static_assert(sizeof(struct dinode) == 104, "dinode size != 104");
+#endif
 
 /* Size of disk inode */
 #define LC_DINODE_SIZE      128


### PR DESCRIPTION
The changes mostly involve adding 
- ifdefs for apple.
- A few missing functions in apple are replaced with the equivalent ones.

State of LCFS on mac
- Able to mount a device with lcfs
- Unable to start docker using lcfs.