### PR TITLE
Fix typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,24 +3,24 @@
 [![Build Status](https://travis-ci.org/portworx/lcfs.svg?branch=master)](https://travis-ci.org/portworx/lcfs)
 [![Go Report Card](https://goreportcard.com/badge/github.com/portworx/lcfs)](https://goreportcard.com/report/github.com/portworx/lcfs)
 
-**_tl;dr:_** Every time you build, pull or destroy a Docker container, you are using a storage driver. Current storage drivers like Device Mapper, AUFS and Overlay2 implement container behavior using file systems designed to run a full OS. We are open-sourcing a file system that is purpose-built for the container lifecycle.  We call this new file system Layer Cloning File System (LCFS).  Because it is designed only for containers, it is up to 2.5x faster to build an image and up to almost 2x faster to pull an image.  We're looking forward to working with the container community to improve and expand this new tool.
+**_tl;dr:_** Every time you build, pull or destroy a Docker container, you are using a storage driver. Current storage drivers like Device Mapper, AUFS, and Overlay2 implement container behavior using file systems designed to run a full OS. We are open-sourcing a file system that is purpose-built for the container lifecycle.  We call this new file system Layer Cloning File System (LCFS).  Because it is designed only for containers, it is up to 2.5x faster to build an image and up to almost 2x faster to pull an image.  We're looking forward to working with the container community to improve and expand this new tool.
  
 
 # Overview
-Layer Cloning FileSystem (LCFS) is a new filesystem purpose-built to be a Docker [storage driver](https://docs.docker.com/engine/userguide/storagedriver/selectadriver/). All Docker images are constructed of layers using storage drivers (graph drivers) like AUFS, OverlayFS, and Device Mapper. As a design principle, LCFS focuses on layers as the first-class citizen. The LCFS filesystem operates directly on top of block devices, as opposed to merging seperate filesystems. Thereby, LCFS aims to directly manage at the container image’s layer level, eliminate the overhead of having a second filesystem that then is merged, and to optimize for density.
+Layer Cloning FileSystem (LCFS) is a new filesystem purpose-built to be a Docker [storage driver](https://docs.docker.com/engine/userguide/storagedriver/selectadriver/). All Docker images are constructed of layers using storage drivers (graph drivers) like AUFS, OverlayFS, and Device Mapper. As a design principle, LCFS focuses on layers as the first-class citizen. The LCFS filesystem operates directly on top of block devices, as opposed to merging separate filesystems. Thereby, LCFS aims to directly manage at the container image’s layer level, eliminate the overhead of having a second filesystem that then is merged, and to optimize for density.
 
-The future direction is to enhance LCFS with cluster-level operations, richer container statistics, and pave the way towards content integrity of container images.
+The future direction is to enhance LCFS with cluster-level operations, provide richer container statistics, and pave the way towards content integrity in container images.
 
 * **cluster operations**: where image pulls can be cooperatively satisfied by images across a group of servers instead of being isolated to a single server, as it is today. 
 * **statistics**: answering what are the most popular layers, and so on. 
 * **content-integrity**: ensuring container content has not been altered. [See OCI scope.](https://www.opencontainers.org/about/oci-scope-table)
 
-LCFS filesystem is an open source project, and we welcome feedback and collaboration. Currently, the driver is at the experimental phase. 
+LCFS filesystem is an open source project, and we welcome feedback and collaboration. The driver is currently experimental. 
 
 # Design Principles 
 Today, running containers on the same server is often limited by side effects that come from mapping container behavior over general filesystems. The approach impacts the entire lifecycle: building, launching, reading data, and exiting containers. 
 
-Historically, filesystems were built with the expectation that content is read/writeable. However, Docker images are constructed using many read-only layers and a single read-write layer. As more containers are launched of the same image (like fedora/apache), reading a file within a container requires traversing (up to) all the other containers running that image. 
+Historically, filesystems were built with the expectation that content is read/writeable. However, Docker images are constructed using many read-only layers and a single read-write layer. As more containers are launched using the same image (like fedora/apache), reading a file within a container requires traversing (up to) all of the other containers running that image. 
 
 The design principles are:
 * **layers are managed directly**: inherently understand layers, their different states, and be able to directly track and manage layers.
@@ -54,7 +54,7 @@ The below table shows a quick comparison of how long it takes LCFS to complete s
 ![alt text](http://i.imgur.com/QAUsMI4.jpg "build times")
 
 ## Architecture 
-The LCFS filesystem is user-level, written in C, POSIX-compliant, and integrated into Linux and macOS via Fuse. It does not require any kernel modifications, enabling it to be portable filesystem. 
+The LCFS filesystem is user-level, written in C, POSIX-compliant, and integrated into Linux and macOS via Fuse. It does not require any kernel modifications, enabling it to be a portable filesystem. 
 
 To start to explain the layers-first design, let us compare launching three containers that use Fedora. In the following diagram, the left side shows a snapshot based storage driver (like Device Mapper or Btrfs). Each container boots from its own read-write (rw) layer and read-only (init) layers. Good. 
 
@@ -62,15 +62,15 @@ However, OS filesystems have been historically built to expect content to be rea
 
 ![alt text] (http://i.imgur.com/vxv3FUW.png "LCFS vs Snapshot driver diagram")
 
-In the above  diagram, the right side shows that LCFS also presents a unified view (mount) for three containers running the Fedora image. The design goal is to unchain how containers access their own content. First, launching the second container results in a new init [clone (not a snapshot)](https://github.com/portworx/lcfs/blob/master/docs/layers_overview.md#snapshots-in-other-drivers-and-clones-in-lcfs). Internally, the access of the second container’s (init) filesystem does not require tracking backwards to an original (snapshot’s) parent. The net effect is that read and modify operations from successive containers do not depend on prior containers. 
+In the above  diagram, the right side shows that LCFS also presents a unified view (mount) for three containers running the Fedora image. The design goal is to unchain how containers access their own content. First, launching the second container results in a new init [clone (not a snapshot)](https://github.com/portworx/lcfs/blob/master/docs/layers_overview.md#snapshots-in-other-drivers-and-clones-in-lcfs). Internally, the access of the second container’s (init) filesystem does not require tracking backward to an original (snapshot’s) parent. The net effect is that read and modify operations from successive containers do not depend on prior containers. 
 
 Separately, LCFS itself is implemented as a single filesystem. It takes in (hardware) devices and puts one filesystem over those drives. For more on the LCFS architecture and future TODOs, please see: 
 
 * [*caching*](https://github.com/portworx/lcfs/blob/master/docs/caching_overview.md): how LCFS caches and accesses metadata (inodes, directories, etc) and future work. 
 * [*crash consistency*](https://github.com/portworx/lcfs/blob/master/docs/crashconsistency_overview.md): work in progress. 
 * [*file operations*](https://github.com/portworx/lcfs/blob/master/docs/file_operations.md): how LCFS supports file operations and file locking.
-* [*layers*](https://github.com/portworx/lcfs/blob/master/docs/layers_overview.md): how layers are created, cloning versus snapshotting, differenced, and locked. 
-* [*layout*](https://github.com/portworx/lcfs/blob/master/docs/layout_overview.md): how LCFS formasts devices, handles inodes, and handles internal data structures. 
+* [*layers*](https://github.com/portworx/lcfs/blob/master/docs/layers_overview.md): how layers are created, differenced, locked, and cloned/snapshotted. 
+* [*layout*](https://github.com/portworx/lcfs/blob/master/docs/layout_overview.md): how LCFS formats devices, handles inodes, and handles internal data structures. 
 * [*space management*](https://github.com/portworx/lcfs/blob/master/docs/spacemanagement_overview.md): how LCFS handles allocation, tracking, placement, and I/O coalescing. 
 * [*stats*](https://github.com/portworx/lcfs/blob/master/docs/stats_overview.md): how to access stats and future work. 
 


### PR DESCRIPTION
Made some notes as I was reading the `README`;
Then, I ran it through Grammarly.
These were some suggested fixes.

This project is cool!

Signed-off-by: leigh schrandt <leigh@null.net>