### PR TITLE
Reduce travis e-mail notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,5 @@ notifications:
     recipients:
       - eng@portworx.com
       - jobi@portworx.com
-    on_success: always
+    on_success: change
     on_failure: always


### PR DESCRIPTION
Only send e-mails on build failures, or when
build transitions from failure to success.